### PR TITLE
[#12]: Adding `user_id` to the jwt.MapClaims

### DIFF
--- a/testing/jwts.go
+++ b/testing/jwts.go
@@ -15,11 +15,9 @@ var (
 
 func NewToken(body *JwtBody) string {
 	logging.RootLog.Debug("Creating JWT with body: %v", body)
-	claims := jwt.MapClaims{
-		"sub":     body.Subject,
-		"user_id": body.UserId,
-		"roles":   body.Roles,
-		"iss":     body.Issuer,
+	claims := jwt.MapClaims{}
+	for k, v := range body.Claims {
+		claims[k] = v
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	ss, _ := token.SignedString(SecretKey)

--- a/testing/jwts.go
+++ b/testing/jwts.go
@@ -16,9 +16,10 @@ var (
 func NewToken(body *JwtBody) string {
 	logging.RootLog.Debug("Creating JWT with body: %v", body)
 	claims := jwt.MapClaims{
-		"sub":   body.Subject,
-		"roles": body.Roles,
-		"iss":   body.Issuer,
+		"sub":     body.Subject,
+		"user_id": body.UserId,
+		"roles":   body.Roles,
+		"iss":     body.Issuer,
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	ss, _ := token.SignedString(SecretKey)

--- a/testing/jwts.go
+++ b/testing/jwts.go
@@ -15,7 +15,11 @@ var (
 
 func NewToken(body *JwtBody) string {
 	logging.RootLog.Debug("Creating JWT with body: %v", body)
-	claims := jwt.MapClaims{}
+	claims := jwt.MapClaims{
+		"sub":   body.Subject,
+		"roles": body.Roles,
+		"iss":   body.Issuer,
+	}
 	for k, v := range body.Claims {
 		claims[k] = v
 	}

--- a/testing/testgenerator.go
+++ b/testing/testgenerator.go
@@ -13,7 +13,6 @@ import (
 const (
 	YamlGlob     = "*.yaml"
 	PoliciesGlob = "*.rego"
-	JwtIssuer    = "iss"
 )
 
 var Log = logging.NewLog("testgen")
@@ -50,10 +49,9 @@ func Generate(SourceDir string) ([]TestUnit, error) {
 		for _, test := range testcase.Tests {
 			testname := strings.Join([]string{testcase.Name, test.Name}, ".")
 			Log.Debug("--- %s", testname)
-			Log.Trace("JWT contents: %v", test.Token.Claims)
-
-			if test.Token.Claims[JwtIssuer] == "" {
-				test.Token.Claims[JwtIssuer] = testcase.Iss
+			Log.Trace("JWT contents: %v", test.Token)
+			if test.Token.Issuer == "" {
+				test.Token.Issuer = testcase.Iss
 			}
 			requests = append(requests, TestUnit{
 				Name:        testname,

--- a/testing/testgenerator.go
+++ b/testing/testgenerator.go
@@ -13,6 +13,7 @@ import (
 const (
 	YamlGlob     = "*.yaml"
 	PoliciesGlob = "*.rego"
+	JwtIssuer    = "iss"
 )
 
 var Log = logging.NewLog("testgen")
@@ -49,9 +50,10 @@ func Generate(SourceDir string) ([]TestUnit, error) {
 		for _, test := range testcase.Tests {
 			testname := strings.Join([]string{testcase.Name, test.Name}, ".")
 			Log.Debug("--- %s", testname)
-			Log.Trace("JWT contents: %v", test.Token)
-			if test.Token.Issuer == "" {
-				test.Token.Issuer = testcase.Iss
+			Log.Trace("JWT contents: %v", test.Token.Claims)
+
+			if test.Token.Claims[JwtIssuer] == "" {
+				test.Token.Claims[JwtIssuer] = testcase.Iss
 			}
 			requests = append(requests, TestUnit{
 				Name:        testname,

--- a/testing/types.go
+++ b/testing/types.go
@@ -48,10 +48,7 @@ type TestBody struct {
 // Based on the Policy, one (or more) of the Roles may allow permissions to access the Resource,
 // and the Test asserts truth of falsity of this statement.
 type JwtBody struct {
-	Subject string   `json:"sub" yaml:"sub"`
-	UserId  string   `json:"user_id" yaml:"user_id"`
-	Roles   []string `json:"roles" yaml:"roles"`
-	Issuer  string   `json:"iss" yaml:"iss"`
+	Claims map[string]interface{} `json:"claims,omitempty" yaml:"claims,omitempty"`
 }
 
 // Target defines the policy that we want to test with the Testcase

--- a/testing/types.go
+++ b/testing/types.go
@@ -48,10 +48,10 @@ type TestBody struct {
 // Based on the Policy, one (or more) of the Roles may allow permissions to access the Resource,
 // and the Test asserts truth of falsity of this statement.
 type JwtBody struct {
-	Subject string   `json:"sub" yaml:"sub"`
-	Roles   []string `json:"roles" yaml:"roles"`
-	Issuer  string   `json:"iss" yaml:"iss"`
-	Claims map[string]interface{} `json:"claims,omitempty" yaml:"claims,omitempty"`
+	Subject string                 `json:"sub" yaml:"sub"`
+	Roles   []string               `json:"roles" yaml:"roles"`
+	Issuer  string                 `json:"iss" yaml:"iss"`
+	Claims  map[string]interface{} `json:"claims,omitempty" yaml:"claims,omitempty"`
 }
 
 // Target defines the policy that we want to test with the Testcase

--- a/testing/types.go
+++ b/testing/types.go
@@ -49,6 +49,7 @@ type TestBody struct {
 // and the Test asserts truth of falsity of this statement.
 type JwtBody struct {
 	Subject string   `json:"sub" yaml:"sub"`
+	UserId  string   `json:"user_id" yaml:"user_id"`
 	Roles   []string `json:"roles" yaml:"roles"`
 	Issuer  string   `json:"iss" yaml:"iss"`
 }

--- a/testing/types.go
+++ b/testing/types.go
@@ -48,6 +48,9 @@ type TestBody struct {
 // Based on the Policy, one (or more) of the Roles may allow permissions to access the Resource,
 // and the Test asserts truth of falsity of this statement.
 type JwtBody struct {
+	Subject string   `json:"sub" yaml:"sub"`
+	Roles   []string `json:"roles" yaml:"roles"`
+	Issuer  string   `json:"iss" yaml:"iss"`
 	Claims map[string]interface{} `json:"claims,omitempty" yaml:"claims,omitempty"`
 }
 


### PR DESCRIPTION
### Summary of Changes
- Adds `user_id` to the `jwt.MapClaims` of generated tokens

### Testing
- Before making this change, an OPA unit test trying to access the `user_id` of a JWT was failing. After making this change locally, running a `make build`, then dropping the generated binary into the OPA project, the test passed