### PR TITLE
add host to the resource object

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ the request would carry this JWT as an `api_token` field (base-64 encoded) and t
     "input": {
         "api_token":"eyJhbG...6I8eHnFU",
         "resource": {
+            "host": "readings.dev.copilotiq.co",
             "path": "/users",
             "method":"POST"
           }

--- a/testing/types.go
+++ b/testing/types.go
@@ -23,6 +23,7 @@ type BundleManifest struct {
 type Resource struct {
 	Path   string `json:"path"`
 	Method string `json:"method"`
+	Host   string `json:"host"`
 }
 
 // A Request is what is typically sent from a REST API server that requires


### PR DESCRIPTION
# Description
- in order to support Host evaluation in OPA policies, the host field was added in the request for opa tests.